### PR TITLE
Changes required in order to run int_to_bags, will be run using 'CVC5…

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -126,6 +126,8 @@ libcvc5_add_sources(
   preprocessing/passes/theory_preprocess.h
   preprocessing/passes/unconstrained_simplifier.cpp
   preprocessing/passes/unconstrained_simplifier.h
+  preprocessing/passes/int_to_bag.cpp
+  preprocessing/passes/int_to_bag.h
   preprocessing/preprocessing_pass.cpp
   preprocessing/preprocessing_pass.h
   preprocessing/preprocessing_pass_context.cpp

--- a/src/options/smt_options.toml
+++ b/src/options/smt_options.toml
@@ -10,6 +10,14 @@ name   = "SMT Layer"
   help       = "eliminate functions by ackermannization"
 
 [[option]]
+  name       = "solveIntAsBags"
+  category   = "regular"
+  long       = "solveIntAsBags"
+  type       = "bool"
+  default    = "false"
+  help       = "convert int to bags"
+
+[[option]]
   name       = "simplificationMode"
   alias      = ["simplification-mode"]
   category   = "regular"

--- a/src/preprocessing/passes/int_to_bag.cpp
+++ b/src/preprocessing/passes/int_to_bag.cpp
@@ -1,0 +1,52 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Yoni Zohar, Gereon Kremer, Mathias Preiner
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2023 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * The BVToInt preprocessing pass.
+ *
+ * Converts bit-vector operations into integer operations.
+ *
+ */
+
+#include "preprocessing/passes/int_to_bag.h"
+
+#include <cmath>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "expr/node.h"
+#include "expr/node_traversal.h"
+#include "options/smt_options.h"
+#include "options/uf_options.h"
+#include "theory/bv/theory_bv_rewrite_rules_operator_elimination.h"
+#include "preprocessing/assertion_pipeline.h"
+#include "theory/bv/theory_bv_rewrite_rules_simplification.h"
+#include "theory/rewriter.h"
+
+namespace cvc5::internal {
+    namespace preprocessing {
+        namespace passes {
+
+            using namespace std;
+            using namespace cvc5::internal::theory;
+
+            IntToBag::IntToBag(PreprocessingPassContext *preprocContext)
+                    : PreprocessingPass(preprocContext, "int-to-bag") {}
+
+            PreprocessingPassResult IntToBag::applyInternal(
+                    AssertionPipeline *assertionsToPreprocess) {
+                return PreprocessingPassResult::NO_CONFLICT;
+            }
+
+        }  // namespace passes
+    }  // namespace preprocessing
+}  // namespace cvc5::internal

--- a/src/preprocessing/passes/int_to_bag.h
+++ b/src/preprocessing/passes/int_to_bag.h
@@ -1,0 +1,43 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Yoni Zohar, Yehonatan Calinsky
+ *
+ * This file is part of the cvc5 project.
+ *
+ * Copyright (c) 2009-2023 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ * ****************************************************************************
+ *
+ * The int-to-bag preprocessing pass.
+ */
+
+#ifndef __CVC5__PREPROCESSING__PASSES__INT_TO_BAG_H
+#define __CVC5__PREPROCESSING__PASSES__INT_TO_BAG_H
+
+
+#include "context/cdhashmap.h"
+#include "context/cdo.h"
+#include "context/context.h"
+#include "preprocessing/preprocessing_pass.h"
+#include "preprocessing/preprocessing_pass_context.h"
+#include "theory/bv/int_blaster.h"
+
+namespace cvc5::internal {
+    namespace preprocessing {
+        namespace passes {
+            class IntToBag : public PreprocessingPass {
+            public:
+                IntToBag(PreprocessingPassContext *preprocContext);
+
+            protected:
+                PreprocessingPassResult applyInternal(
+                        AssertionPipeline *assertionsToPreprocess) override;
+            };
+
+        }  // namespace passes
+    }  // namespace preprocessing
+}  // namespace cvc5::internal
+
+#endif //__CVC5__PREPROCESSING__PASSES__INT_TO_BAG_H

--- a/src/smt/process_assertions.cpp
+++ b/src/smt/process_assertions.cpp
@@ -163,6 +163,11 @@ bool ProcessAssertions::apply(AssertionPipeline& ap)
     applyPass("ackermann", ap);
   }
 
+  if (options().smt.solveIntAsBags)
+  {
+      applyPass("int-to-bag", ap);
+  }
+
   Trace("smt") << " assertions     : " << ap.size() << endl;
 
   bool noConflict = true;


### PR DESCRIPTION
…_REGRESSION_ARGS="--solveIntAsBags" ctest'.

For now only make tests fail.